### PR TITLE
Refactor runner with basedir and isolation options

### DIFF
--- a/example/git
+++ b/example/git
@@ -1,8 +1,25 @@
 #!/usr/bin/env ruby
 require 'mister_bin'
 
-exitcode =  MisterBin::Runner.run __FILE__, ARGV,
+# All options are... optional.
+options = {
+  # Text to display before/after the list of commands
   header: "This is a sample header.",
-  footer: "This is a sample footer.\nUse --help for each command to get more information"
+  footer: "This is a sample footer.\nUse --help for each command to get more information",
 
+  # Additional dir (in addition to PATH) to search for commands
+  basedir: __dir__,
+
+  # If true, will only search in `basedir` and not in PATH.
+  isolate: false
+}
+
+# Create the runner object, the first parameter being the name of the main
+# executable.
+runner = MisterBin::Runner.new 'git', options
+
+# Run and provide the arguments from the command line to the runner
+exitcode =  runner.run ARGV
+
+# Exit politely, with a proper exit code
 exit exitcode

--- a/lib/mister_bin/commands.rb
+++ b/lib/mister_bin/commands.rb
@@ -2,11 +2,12 @@ module MisterBin
 
   # This class handles listing and finding command files
   class Commands
-    attr_reader :basename, :basedir
+    attr_reader :basename, :basedir, :isolate
 
-    def initialize(basename, basedir='.')
+    def initialize(basename, basedir='.', isolate: false)
       @basename = basename
       @basedir = basedir
+      @isolate = isolate
     end
 
     def all
@@ -45,7 +46,13 @@ module MisterBin
     end
 
     def path_helper
-      @path_helper ||= PathHelper.new(additional_dir: basedir)
+      @path_helper ||= path_helper!
+    end
+
+    def path_helper!
+      helper = PathHelper.new(additional_dir: basedir)
+      helper.paths = [basedir] if isolate
+      helper
     end
   end
 end

--- a/lib/mister_bin/path_helper.rb
+++ b/lib/mister_bin/path_helper.rb
@@ -2,6 +2,7 @@ module MisterBin
 
   class PathHelper
     attr_reader :pathspec, :additional_dir
+    attr_writer :paths
 
     def initialize(additional_dir: nil, pathspec: nil)
       @additional_dir = additional_dir

--- a/lib/mister_bin/runner.rb
+++ b/lib/mister_bin/runner.rb
@@ -4,18 +4,14 @@ module MisterBin
   class Runner
     include Colsole
 
-    attr_reader :basefile, :basedir, :name, :header, :footer
+    attr_reader :name, :basedir, :header, :footer, :isolate
 
-    def self.run(basefile, argv=[], header: nil, footer: nil)
-      new(basefile, header: header, footer: footer).run argv
-    end
-
-    def initialize(basefile, header: nil, footer: nil)
-      @basefile = basefile
-      @header = header
-      @footer = footer
-      @basedir = File.dirname basefile
-      @name = File.basename basefile
+    def initialize(name, opts={})
+      @name = name
+      @header = opts[:header]
+      @footer = opts[:footer]
+      @isolate = opts[:isolate]
+      @basedir = opts[:basedir]
     end
 
     def run(argv=[])
@@ -57,7 +53,7 @@ module MisterBin
     end
 
     def commands
-      @commands ||= Commands.new name, basedir
+      @commands ||= Commands.new name, basedir, isolate: isolate
     end
   end
 end

--- a/spec/fixtures/runner/isolate-false
+++ b/spec/fixtures/runner/isolate-false
@@ -1,0 +1,5 @@
+Commands:
+  app lause
+  app ls
+  app why
+  app workspace create

--- a/spec/fixtures/runner/isolate-true
+++ b/spec/fixtures/runner/isolate-true
@@ -1,0 +1,2 @@
+Commands:
+  app lause

--- a/spec/mister_bin/commands_spec.rb
+++ b/spec/mister_bin/commands_spec.rb
@@ -8,6 +8,22 @@ describe Commands do
       expect(subject.all).to be_a Hash
       expect(subject.all['ls']).to be_a Command
     end
+
+    context "when isolate=false" do
+      it "does not override PATH" do
+        expect_any_instance_of(PathHelper).not_to receive(:'paths=')
+        expect(subject.all).to be_a Hash
+      end
+    end
+
+    context "when isolate=true" do
+      subject { described_class.new 'app', 'spec/workspace', isolate: true }
+
+      it "overrides PATH" do
+        expect_any_instance_of(PathHelper).to receive(:'paths=')
+        expect(subject.all).to be_a Hash
+      end
+    end
   end
 
   describe '#names' do
@@ -16,7 +32,7 @@ describe Commands do
     end
   end
 
-  describe '#find', :focus do
+  describe '#find' do
     context "when searching for a secondary command" do
       it "returns a matching command" do
         command = subject.find('workspace', 'create')

--- a/spec/mister_bin/path_helper_spec.rb
+++ b/spec/mister_bin/path_helper_spec.rb
@@ -45,4 +45,12 @@ describe PathHelper do
       end
     end
   end
+
+  describe '#paths=' do
+    it "allows overriding the array of paths" do
+      expect(subject.paths.size).to be > 1
+      subject.paths = ['some/dir']
+      expect(subject.paths.size).to eq 1
+    end
+  end
 end

--- a/spec/workspace/somedir/app-lause.rb
+++ b/spec/workspace/somedir/app-lause.rb
@@ -1,0 +1,2 @@
+usage "app lause"
+action { puts "clap " * 50 }


### PR DESCRIPTION
This PR makes the Runner NOT backwards compatible.

Changes include:

- `Runner` no longer has the static `Runner::run` method. It is now needed to instantiate a `Runner` object, and then call its `#run` method.
- `Runner` instance no longer accepts `basefile`. Instead, it accepts a name only. To specify a `basedir`, you will need to provide it in the `options` hash
- An `isolate` option was added to the runner. If `true`, the runner will only search for commands in the `basedir` directory, and not in any of the `PATH` directories.

The objectives of this PR are to:

`. Make calling the Runner more intuitive.
- Allow to opt out of the extensibility feature.
- Allow to explicitly specify a command dir, instead of forcing the opinion that the main app should live in the same place as its commands.

Tests were added to verify everything, coverage should remain 100%
