### PR TITLE
Move args from #run to attr_accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ runner.route_all to: GlobalCommand
 Creating Commands
 --------------------------------------------------
 
-Create command classes by in heriting from `MisterBin::Command`, for example:
+Create command classes by inheriting from `MisterBin::Command`, for example:
 
 ```ruby
 require 'mister_bin'
@@ -173,7 +173,8 @@ class GreetCommand < MisterBin::Command
   usage "app greet [NAME]"
   param "NAME", "The recipient of the greeting"
 
-  def run(args)
+  def run
+    # args hash is available everywhere in the calss
     name = args['NAME'] || 'Luke'
     puts "#{name}... I am your father..."
   end

--- a/examples/01-minimal/app.rb
+++ b/examples/01-minimal/app.rb
@@ -7,7 +7,7 @@ class GreetCommand < MisterBin::Command
   usage "app greet [NAME]"
   param "NAME", "The recipient of the greeting"
 
-  def run(args)
+  def run
     name = args['NAME'] || 'Luke'
     puts "#{name}... I am your father..."
   end

--- a/examples/02-full/app.rb
+++ b/examples/02-full/app.rb
@@ -43,16 +43,16 @@ class DemoCommand < MisterBin::Command
   # Implementation
   # In this example, the `ls` and `new` commands have specialized handlers,
   # while the `delete` command, will fall back to the `run` method.
-  def ls_command(args)
+  def ls_command
     puts args['--all'] ? "Run this: ls -la" : "Run that: ls"
   end
 
-  def new_command(args)
+  def new_command
     name = args['NAME'] || 'Luke'
     puts "#{name}... I am your father..."
   end
 
-  def run(args)
+  def run
     puts "Fallback. A command that has no direct handler was called."
     p args
   end

--- a/examples/03-multiple-commands/app.rb
+++ b/examples/03-multiple-commands/app.rb
@@ -7,7 +7,7 @@ class GreetCommand < MisterBin::Command
   usage "app greet [NAME]"
   param "NAME", "The recipient of the greeting"
 
-  def run(args)
+  def run
     name = args['NAME'] || 'Luke'
     puts "#{name}... I am your father..."
   end
@@ -32,7 +32,7 @@ class DirCommand < MisterBin::Command
 
   environment 'SECRET', 'There is no spoon'
 
-  def run(args)
+  def run
     puts args['--all'] ? "success --all" : "success"
   end
 end

--- a/examples/04-global-command/app.rb
+++ b/examples/04-global-command/app.rb
@@ -6,7 +6,7 @@ class GlobalCommand < MisterBin::Command
   usage "app say [MESSAGE]"
   usage "app shout [MESSAGE]"
 
-  def run(args)
+  def run
     message = args['MESSAGE'] || 'hello'
 
     if args['say']

--- a/examples/05-using-shortcuts/app.rb
+++ b/examples/05-using-shortcuts/app.rb
@@ -6,7 +6,7 @@ class ServerCommand < MisterBin::Command
   usage "app server start"
   usage "app server stop"
 
-  def run(args)
+  def run
     p args
   end
 end
@@ -15,7 +15,7 @@ end
 class SayCommand < MisterBin::Command
   usage "app say SOMETHING"
 
-  def run(args)
+  def run
     p args
   end
 end
@@ -24,7 +24,7 @@ end
 class ConfigCommand < MisterBin::Command
   usage "app config edit"
 
-  def run(args)
+  def run
     p args
   end
 end

--- a/lib/mister_bin/command.rb
+++ b/lib/mister_bin/command.rb
@@ -5,6 +5,12 @@ module MisterBin
   class Command
     include Colsole
 
+    attr_reader :args
+
+    def initialize(args)
+      @args = args
+    end
+
     class << self
       def description
         maker.summary || maker.help || ''
@@ -12,9 +18,9 @@ module MisterBin
 
       def execute(argv=[])
         args = Docopt.docopt docopt, version: maker.version, argv: argv
-        instance = new 
+        instance = new args
         target = find_target_command instance, args
-        exitcode = instance.send target, args
+        exitcode = instance.send target
         exitcode.is_a?(Numeric) ? exitcode : 0
 
       rescue Docopt::Exit => e

--- a/spec/samples/dir_command.rb
+++ b/spec/samples/dir_command.rb
@@ -20,7 +20,7 @@ class DirCommand < MisterBin::Command
 
   environment 'SECRET', 'There is no spoon'
 
-  def run(args)
+  def run
     puts args['--all'] ? "success --all" : "success"
   end
 end

--- a/spec/samples/global_command.rb
+++ b/spec/samples/global_command.rb
@@ -1,7 +1,7 @@
 class GlobalCommand < MisterBin::Command
   usage "app greet NAME"
 
-  def run(args)
+  def run
     puts "hello #{args['NAME']}"
   end
 end


### PR DESCRIPTION
**Caution: This is a breaking change**

Command methods no longer receive `args` as an argument.
Instead, it is available to the subclass by means of `attr_reader`.

Upgrading your tools to the new format just means some minor modifications:

```ruby
def run(args)    # old
def run          # new
def some_command(args)    # old
def some_command          # new
```

That's it. Of course if you took some steps to make `args` available throughout your class, you can remove these as well.

