### PR TITLE
Make command meta data available to outside callers

### DIFF
--- a/lib/mister_bin.rb
+++ b/lib/mister_bin.rb
@@ -1,5 +1,5 @@
 require 'mister_bin/command'
-require 'mister_bin/docopt_maker'
+require 'mister_bin/command_meta'
 require 'mister_bin/runner'
 
 require 'byebug' if ENV['BYEBUG']

--- a/lib/mister_bin/command.rb
+++ b/lib/mister_bin/command.rb
@@ -7,17 +7,17 @@ module MisterBin
 
     attr_reader :args
 
-    def initialize(args)
+    def initialize(args = nil)
       @args = args
     end
 
     class << self
       def description
-        maker.summary || maker.help || ''
+        meta.summary || meta.help || ''
       end
 
       def execute(argv=[])
-        args = Docopt.docopt docopt, version: maker.version, argv: argv
+        args = Docopt.docopt docopt, version: meta.version, argv: argv
         instance = new args
         target = find_target_command instance, args
         exitcode = instance.send target
@@ -31,50 +31,50 @@ module MisterBin
       # DSL
 
       def summary(text)
-        maker.summary = text
+        meta.summary = text
       end
 
       def help(text)
-        maker.help = text
+        meta.help = text
       end
 
       def version(text)
-        maker.version = text
+        meta.version = text
       end
 
       def usage(text)
-        maker.usages << text
+        meta.usages << text
       end
 
       def option(flags, text)
-        maker.options << [flags, text]
+        meta.options << [flags, text]
       end
 
       def command(name, text)
         target_commands << name.to_sym
-        maker.commands << [name, text]
+        meta.commands << [name, text]
       end
 
       def param(param, text)
-        maker.params << [param, text]
+        meta.params << [param, text]
       end
 
       def example(text)
-        maker.examples << text
+        meta.examples << text
       end
 
       def environment(name, value)
-        maker.env_vars << [name, value]
+        meta.env_vars << [name, value]
+      end
+
+      def meta
+        @meta ||= CommandMeta.new
       end
 
     protected
 
-      def maker
-        @maker ||= DocoptMaker.new
-      end
-
       def docopt
-        maker.docopt
+        meta.docopt
       end
 
     private
@@ -92,6 +92,5 @@ module MisterBin
       end
 
     end
-
   end
 end

--- a/lib/mister_bin/command_meta.rb
+++ b/lib/mister_bin/command_meta.rb
@@ -2,9 +2,9 @@ require 'colsole'
 
 module MisterBin
 
-  # This singleton class is responsible for generating a text string ready to be used
-  # by Docopt. 
-  class DocoptMaker
+  # This class is responsible for holding all the meta data for a command and
+  # for generating a text string ready to be used by Docopt. 
+  class CommandMeta
     include Colsole
 
     attr_reader :usages, :options, :examples, :params, :commands, :env_vars
@@ -27,7 +27,7 @@ module MisterBin
         options_string, params_string, env_string, examples_string].compact.join "\n"
     end
 
-    private
+  private
 
     def summary_string
       summary ? word_wrap(summary) + "\n" : nil
@@ -97,5 +97,6 @@ module MisterBin
 
       result.join "\n"
     end
+
   end
 end

--- a/spec/mister_bin/command_meta_spec.rb
+++ b/spec/mister_bin/command_meta_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe DocoptMaker do
+describe CommandMeta do
   describe '#docopt' do
     context "with all properties set" do
       before do


### PR DESCRIPTION
With the simple change of renaming `DocoptHelper` to `CommandMeta`, it is now accessible to the outside callers, so anybody can use the command's eigenclass to access its entire set of properties.

Simply call `YourCommand.meta` to get all the structured meta data.