### PR TITLE
Change super --help format

### DIFF
--- a/lib/mister_bin/runner.rb
+++ b/lib/mister_bin/runner.rb
@@ -99,8 +99,12 @@ module MisterBin
       say "#{header}\n" if header
 
       commands.each do |key, command|
-        say "!bldgrn!#{key}"
-        say word_wrap "  #{command.meta.long_description}"
+        meta = command.meta
+        next unless meta.help or meta.summary
+
+        say "!txtgrn!#{key}"
+        help = meta.help || meta.summary
+        say word_wrap "  #{help}"
         say ""
       end
 

--- a/spec/fixtures/examples/03-multiple-commands/app --help
+++ b/spec/fixtures/examples/03-multiple-commands/app --help
@@ -4,8 +4,6 @@ greet
   Say hi
 
 dir
-  Show list of files
-  
   A longer help can optionallly go here.
 
 For additional info, run app --help or app COMMAND --help

--- a/spec/fixtures/examples/03-multiple-commands/app -h
+++ b/spec/fixtures/examples/03-multiple-commands/app -h
@@ -4,8 +4,6 @@ greet
   Say hi
 
 dir
-  Show list of files
-  
   A longer help can optionallly go here.
 
 For additional info, run app --help or app COMMAND --help

--- a/spec/fixtures/integration/help
+++ b/spec/fixtures/integration/help
@@ -1,9 +1,7 @@
 This is a sample header.
 
-[1;32mdir
-[0m  Show list of files and more
-  
-  A longer help can optionallly go here.
+[0;32mdir
+[0m  A longer help can optionallly go here.
 
 This is a sample footer.
 Use --help for each command to get more information


### PR DESCRIPTION
The super --help flag will now avoid showing the summary line, and instead only show the help string. If the help string is empty, the summary line will be used instead. If both are empty, the command will not be displayed in the super --help.