### PR TITLE
Add custom command blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,19 @@ terminal = MisterBin::Terminal.new runner, {
 }
 ```
 
+In addition, you may wish to provide your own code blocks for handling some
+commands that are not handled by your runner. For example, this piece of code
+will capture the `/cd ...` command from the terminal and pass it to your 
+block:
+
+```
+terminal = MisterBin::Terminal.new runner
+terminal.on '/cd' do |args|
+  Dir.chdir args[0] if args[0]
+  puts Dir.pwd
+end
+```
+
 These are the available options. All string options are displayed with 
 the [Colsole][5] `say` command so they support color markers.
 
@@ -321,6 +334,10 @@ The prefix character that if typed at the beginning of a command, will avoid
 executing the runner, and instead execute a system (shell) command. 
 Default: `"/"`.
 
+#### `disable_system_shell`
+
+If true, commands that start with `/` will *not* be delegated to the stsrem.
+Default: `false`.
 
 
 In the Wild

--- a/examples/06-terminal/app.rb
+++ b/examples/06-terminal/app.rb
@@ -21,6 +21,14 @@ terminal = MisterBin::Terminal.new runner, {
   header: "Welcome",
   autocomplete: %w[--help greet]
 }
+
+# optionally, define custom command overrides
+terminal.on '/cd' do |args|
+  Dir.chdir args[0] if args[0]
+  puts Dir.pwd
+end
+
+# start the terminal
 terminal.start
 
 

--- a/spec/fixtures/terminal/reserved
+++ b/spec/fixtures/terminal/reserved
@@ -1,0 +1,2 @@
+/hello called
+["world", "of", "goo"]

--- a/spec/mister_bin/terminal_spec.rb
+++ b/spec/mister_bin/terminal_spec.rb
@@ -61,6 +61,15 @@ describe Terminal do
         expect(subject).to receive(:system).with('ls -la')
         subject.start
       end
+
+      context "when system shell is disabled" do
+        let(:options) { { disable_system_shell: true } }
+
+        it "does not run the system command" do
+          expect(subject).not_to receive(:system).with('ls -la')
+          subject.start
+        end
+      end
     end
 
     context "with the exit command" do
@@ -69,6 +78,21 @@ describe Terminal do
 
       it "exits the terminal" do
         expect { subject.start }.to output_fixture 'terminal/exit'
+      end
+    end
+
+    context "with predefined reserved commands" do
+      let(:input) { ["/hello world of goo", false] }
+
+      before do
+        subject.on '/hello' do |args|
+          puts "/hello called"
+          p args
+        end
+      end
+
+      it "executes the block" do
+        expect { subject.start }.to output_fixture 'terminal/reserved'
       end
     end
 


### PR DESCRIPTION
System commands such as `/cd somedir` had no effect in the mister bin terminal, due to the fact that the working directory of the Ruby process did not change once the stsrem command `cd` exited.

This PR solves the problem and adds another nifty capability: You can now use the below syntax to capture specific commands in the terminal and execute your own code block:

```ruby
terminal = MisterBin::Terminal.new runner

# this is new
terminal.on '/cd' do |args|
  Dir.chdir args[0] if args[0]
  puts Dir.pwd
end

terminal.start
```

In addition, this PR adds a `disable_system_shell` boolean option for those who wish to prevent users from using the terminal to call system commands.


See the full example here:

https://github.com/DannyBen/mister_bin/blob/86bdf6d3f2e4b5d43185eb5784471874163db142/examples/06-terminal/app.rb#L25-L29