### PR TITLE
Add `Command#execute` to allow for improved testability

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rspec
+require:
+  - rubocop-rspec
+  - rubocop-performance
 
 inherit_gem:
   rentacop: rentacop.yml
@@ -10,9 +12,11 @@ AllCops:
 
 # === RSpec
 
-# Allow using `describe` with anything
+# Allow using `describe` with any string in some cases
 RSpec/DescribeClass:
-  Enabled: false
+  Exclude:
+    - spec/mister_bin/integration_spec.rb
+    - spec/mister_bin/xamples_spec.rb
 
 # The examples spec is special, it is allowed to be longer
 RSpec/ExampleLength:

--- a/lib/mister_bin/command.rb
+++ b/lib/mister_bin/command.rb
@@ -5,7 +5,7 @@ module MisterBin
   class Command
     include Colsole
 
-    attr_accessor :args
+    attr_reader :args
 
     def execute(argv = [])
       @args = Docopt.docopt self.class.docopt, version: self.class.meta.version, argv: argv

--- a/spec/approvals/command/dir_command_usage
+++ b/spec/approvals/command/dir_command_usage
@@ -1,0 +1,4 @@
+Usage:
+  app dir
+  app dir --all
+  app dir DIR

--- a/spec/mister_bin/command_spec.rb
+++ b/spec/mister_bin/command_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+require_relative '../samples/dir_command'
+
+describe Command do
+  subject(:command) { DirCommand.new }
+
+  describe '#execute' do
+    it 'runs the command' do
+      expect { command.execute }.to output_approval('command/dir_command_usage')
+    end
+  end
+end


### PR DESCRIPTION
Before this PR, testing objects that inherit from `Command` was done through the `Runner` object. This worked fine, but was limiting in some cases.

This PR refactors the `Command` object a little, to allow using it directly as a spec subject.

### before

```ruby
describe Command do
  subject { CLI.router }

  it "shows usage" do
    expect { subject.run }.to output_approval('cli/usage')
  end
end
```


### After

```ruby
describe Command do
  subject { described_class.new }

  it 'shows usage' do
    expect { subject.execute }.to output_approval('cli/usage')
  end
end
```
