### PR TITLE
Fix Command#initialize to receive args

### DIFF
--- a/lib/mister_bin/command.rb
+++ b/lib/mister_bin/command.rb
@@ -7,6 +7,10 @@ module MisterBin
 
     attr_reader :args
 
+    def initialize(args = nil)
+      @args = args
+    end
+
     def execute(argv = [])
       @args = Docopt.docopt self.class.docopt, version: self.class.meta.version, argv: argv
       target = self.class.find_target_command self, args

--- a/spec/mister_bin/command_spec.rb
+++ b/spec/mister_bin/command_spec.rb
@@ -2,7 +2,17 @@ require 'spec_helper'
 require_relative '../samples/dir_command'
 
 describe Command do
-  subject(:command) { DirCommand.new }
+  subject(:command) { DirCommand.new args }
+
+  let(:args) { nil }
+
+  describe '#initialize' do
+    let(:args) { { 'FILE' => 'out.txt', '--verbose' => false } }
+
+    it 'accepts hash arguments' do
+      expect(command.args).to eq args
+    end
+  end
 
   describe '#execute' do
     it 'runs the command' do


### PR DESCRIPTION
Version 0.7.2 introduce a subtle bug by removing the `args` parameter from the initialize.
This caused user code that called command directly like this:

```ruby
SomeCommand.new(args).run
```
to fail.

This pattern is in use in [audio_addict](https://github.com/DannyBen/audio_addict)
