### PR TITLE
Switch from `readline` to `reline`

### DIFF
--- a/lib/mister_bin/terminal.rb
+++ b/lib/mister_bin/terminal.rb
@@ -1,4 +1,4 @@
-require 'readline'
+require 'reline'
 require 'colsole'
 require 'shellwords'
 
@@ -18,8 +18,8 @@ module MisterBin
     end
 
     def start
-      Readline.completion_append_character = ' '
-      Readline.completion_proc = autocomplete_handler if autocomplete
+      Reline.completion_append_character = ' '
+      Reline.completion_proc = autocomplete_handler if autocomplete
 
       welcome_messages
       loop { break unless safe_input_loop }
@@ -78,7 +78,7 @@ module MisterBin
     end
 
     def input_loop
-      while (input = Readline.readline prompt, true)
+      while (input = Reline.readline prompt, true)
         break unless execute input
       end
     end

--- a/mister_bin.gemspec
+++ b/mister_bin.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'colsole', '~> 1.0.0'
   s.add_dependency 'docopt_ng', '~> 0.7.1'
-  s.add_dependency 'readline', '~> 0.0'
+  s.add_dependency 'reline', '~> 0.6'
 
   s.metadata = {
     'bug_tracker_uri'       => 'https://github.com/DannyBen/mister_bin/issues',

--- a/spec/mister_bin/terminal_spec.rb
+++ b/spec/mister_bin/terminal_spec.rb
@@ -24,11 +24,11 @@ describe Terminal do
     end
 
     it 'applies the options to the terminal' do
-      allow(Readline).to receive(:readline)
+      allow(Reline).to receive(:readline)
         .with(options[:prompt], true)
         .and_return('quit')
 
-      expect(Readline).to receive(:completion_proc=)
+      expect(Reline).to receive(:completion_proc=)
 
       expect { terminal.start }.to output_approval 'terminal/options'
     end
@@ -38,7 +38,7 @@ describe Terminal do
     let(:input) { ['--help', false] }
 
     before do
-      allow(Readline).to receive(:readline).and_return(*input)
+      allow(Reline).to receive(:readline).and_return(*input)
     end
 
     it 'starts a terminal that runs commands on the runner' do


### PR DESCRIPTION
Switch from the old bundled `readline` to newer, api-compatible `reline` gem for terminal line reader.